### PR TITLE
Add dev container and session scaffolding

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get install -y curl ca-certificates gnupg lsb-release apt-transport-https \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install kubectl
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/kubernetes-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list \
+    && apt-get update \
+    && apt-get install -y kubectl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install helm
+RUN curl https://baltocdn.com/helm/signing.asc | gpg --dearmor -o /usr/share/keyrings/helm.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" > /etc/apt/sources.list.d/helm-stable-debian.list \
+    && apt-get update \
+    && apt-get install -y helm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install kind
+RUN curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64 \
+    && chmod +x /usr/local/bin/kind
+
+# Install Node.js LTS
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional Ollama install script
+COPY install-ollama.sh /usr/local/bin/install-ollama
+RUN chmod +x /usr/local/bin/install-ollama
+
+CMD [ "bash" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "kube-and-coffee",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "runArgs": ["--privileged"],
+    "postCreateCommand": "kind create cluster || true",
+    "features": {},
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash"
+            },
+            "extensions": [
+                "ms-kubernetes-tools.vscode-kubernetes-tools",
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    }
+}

--- a/.devcontainer/install-ollama.sh
+++ b/.devcontainer/install-ollama.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Installs Ollama inside the container. This script is optional and
+# is not executed automatically.
+
+curl -fsSL https://ollama.ai/install.sh | bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Node artifacts
+node_modules/
+
+# Local env files
+.env
+
+# Devcontainer volumes
+.devcontainer/local/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# kube-and-coffee
+# Kube and Coffee
+
+This repository accompanies a series of talks that teach the fundamentals of Kubernetes for software engineers. Each session builds on the last and the code is separated by session for easy reference.
+
+## Getting Started
+
+### Prerequisites
+* **Docker** – install [Docker Desktop](https://www.docker.com/products/docker-desktop/) for macOS.
+* **Visual Studio Code** – with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+
+### Using the Dev Container
+1. Clone this repository.
+2. Open it in VS Code and choose **Reopen in Container** when prompted.
+3. The first build installs Node.js, `kubectl`, `helm` and `kind`. A local Kubernetes cluster is created automatically.
+4. (Optional) Run `install-ollama` inside the dev container to add [Ollama](https://ollama.ai) for AI‑generated manifests.
+
+### Repository Structure
+
+```
+.sessions/          # Each numbered folder contains examples for a talk
+└── 01-namespace-of-mind/
+    └── README.md   # Session notes and hands-on steps
+```
+
+You can work through the sessions in order. As the series grows, the dev container will evolve to include more tools.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/sessions/01-namespace-of-mind/README.md
+++ b/sessions/01-namespace-of-mind/README.md
@@ -1,0 +1,17 @@
+# Session 1: Namespace of Mind
+
+This session builds intuition for how namespaces isolate workloads and control access.
+
+## Goals
+* Understand what namespaces are and why they matter
+* Create and explore namespaces using `kubectl`
+* Deploy applications into multiple namespaces and observe isolation
+* Experiment with RBAC basics
+
+## Exercises
+1. Create a namespace and deploy a service in it.
+2. Explore namespace‑scoped commands (`kubectl get pods -n <name>`).
+3. Deploy a second instance of the same service in another namespace.
+4. Break something and fix it.
+
+_Optional_: Use [Ollama](https://ollama.ai) to generate namespace‑scoped manifests.

--- a/sessions/02-whats-in-a-pod/README.md
+++ b/sessions/02-whats-in-a-pod/README.md
@@ -1,0 +1,15 @@
+# Session 2: What's in a Pod?
+
+Dive into the pod lifecycle and deployment fundamentals.
+
+## Goals
+* Compare pods, deployments and replica sets
+* Learn about init containers and sidecars
+* Inspect pod status and events
+* Understand common failure modes
+
+## Exercises
+1. Deploy a simple Node.js app.
+2. Scale it up and down.
+3. Break it with a bad image and watch events with `kubectl describe`.
+4. Add labels and query by label selectors.

--- a/sessions/03-keeping-secrets-sharing-configs/README.md
+++ b/sessions/03-keeping-secrets-sharing-configs/README.md
@@ -1,0 +1,14 @@
+# Session 3: Keeping Secrets, Sharing Configs
+
+Configuration management and handling sensitive data.
+
+## Goals
+* Use ConfigMaps and Secrets
+* Mount config as environment variables and volumes
+* Work with namespace‑scoped secrets
+* See how these concepts map to Helm charts
+
+## Exercises
+1. Mount configuration via both env vars and volumes.
+2. Encode and decode a secret with `base64`.
+3. Use a Secret and ConfigMap inside a Helm `values.yaml`.

--- a/sessions/04-pvc-you-later/README.md
+++ b/sessions/04-pvc-you-later/README.md
@@ -1,0 +1,13 @@
+# Session 4: PVC You Later
+
+An introduction to persistent storage and StatefulSets.
+
+## Goals
+* Understand PersistentVolumes, Claims and StorageClasses
+* Learn why stateful workloads are special
+* Explore StatefulSets and their identity guarantees
+
+## Exercises
+1. Create a PVC and attach it to a Deployment.
+2. Convert the Deployment to a StatefulSet.
+3. Move a file in and out of the volume using `kubectl cp`.

--- a/sessions/05-pods-that-scale-themselves/README.md
+++ b/sessions/05-pods-that-scale-themselves/README.md
@@ -1,0 +1,13 @@
+# Session 5: Pods that Scale Themselves
+
+Autoscaling and metrics-driven behavior.
+
+## Goals
+* Explore the Horizontal Pod Autoscaler (HPA)
+* Discuss KEDA and event-driven scaling
+* Understand metrics pipelines
+
+## Exercises
+1. Deploy an app with an HPA based on CPU.
+2. Simulate load and watch it scale.
+3. Discuss how KEDA hooks into event sources (demo optional).

--- a/sessions/06-bring-the-helm-down/README.md
+++ b/sessions/06-bring-the-helm-down/README.md
@@ -1,0 +1,13 @@
+# Session 6: Bring the Helm Down
+
+Templating and packaging manifests with Helm.
+
+## Goals
+* Understand Helm chart structure
+* Work with `values.yaml` and template helpers
+* Install and customize third-party charts
+
+## Exercises
+1. Install something like nginx or metrics-server with Helm.
+2. Customize values during install.
+3. Package your own simple chart from raw manifests.

--- a/sessions/07-mesh-and-tell/README.md
+++ b/sessions/07-mesh-and-tell/README.md
@@ -1,0 +1,13 @@
+# Session 7: Mesh and Tell
+
+An introduction to service meshes and sidecar networking.
+
+## Goals
+* Understand what a service mesh provides
+* Decide when to use a mesh
+* Learn the basics of Istio
+
+## Exercises
+1. Deploy sample apps (e.g. Bookinfo).
+2. Add routing logic such as traffic splits or delays.
+3. Observe request tracing and metrics in the mesh.


### PR DESCRIPTION
## Summary
- initialize VS Code dev container with Node.js and Kubernetes tooling
- add optional `install-ollama` helper
- organize code by numbered session folders
- provide project instructions in README
- add .gitignore

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840d4f4f2288321b4a78155d2f9a366