### PR TITLE
Expand session 1 guide

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
         "dockerfile": "Dockerfile"
     },
     "runArgs": ["--privileged"],
-    "postCreateCommand": "kind create cluster || true",
+    "postCreateCommand": "kind create cluster --config .devcontainer/kind-config.yaml || true",
     "features": {},
     "customizations": {
         "vscode": {

--- a/.devcontainer/kind-config.yaml
+++ b/.devcontainer/kind-config.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 31434
+    hostPort: 11434
+    protocol: TCP
+  - containerPort: 31080
+    hostPort: 3080
+    protocol: TCP

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This repository accompanies a series of talks that teach the fundamentals of Kub
 ### Using the Dev Container
 1. Clone this repository.
 2. Open it in VS Code and choose **Reopen in Container** when prompted.
-3. The first build installs Node.js, `kubectl`, `helm` and `kind`. A local Kubernetes cluster is created automatically.
-4. (Optional) Run `install-ollama` inside the dev container to add [Ollama](https://ollama.ai) for AI‑generated manifests.
+3. The first build installs Node.js, `kubectl`, `helm` and `kind`. A local Kubernetes cluster is created automatically using `.devcontainer/kind-config.yaml` which exposes ports `11434` and `3080` on the host.
+4. (Optional) Run `install-ollama` inside the dev container to add [Ollama](https://ollama.ai) for AI‑generated manifests. Example manifests for an Ollama service and a LibreChat UI are included in `sessions/01-namespace-of-mind/`.
+5. CoreDNS is deployed by default so services can resolve each other via DNS.
 
 ### Repository Structure
 

--- a/sessions/01-namespace-of-mind/README.md
+++ b/sessions/01-namespace-of-mind/README.md
@@ -2,16 +2,85 @@
 
 This session builds intuition for how namespaces isolate workloads and control access.
 
+## What Are Namespaces?
+
+Kubernetes namespaces provide logical boundaries within a cluster. Objects
+like pods, services and ConfigMaps are **namespaced**. That means you can have
+resources with the same name living in different namespaces without conflicts.
+
+Namespaces are an easy way to separate concerns:
+
+- **Environment isolation** – keep `dev`, `test` and `prod` workloads apart.
+- **Team ownership** – give each team or feature its own sandbox.
+- **RBAC scoping** – grant permissions on a per‑namespace basis.
+
+In the provided devcontainer a local [kind](https://kind.sigs.k8s.io/) cluster is
+created automatically and your `kubectl` context is pointed to it. Everything in
+this session can be run there; you don't need any cloud resources. The cluster is
+ephemeral, so restarting the devcontainer or running `kind delete cluster` will
+wipe any namespaces you create.
+
+## When to Create a Namespace
+
+Namespaces are ideal for grouping resources that share a lifecycle or ownership.
+For example, you might use one namespace for a microservice and another for a
+database if they need to be deployed and managed independently. They are also
+handy for short‑lived experiments so you can delete everything in one command.
+
+When deciding what belongs in a namespace, ask yourself:
+
+- Do these resources need to be upgraded or rolled back together?
+- Should only a specific team have access to them?
+- Would cleaning them up as a group be useful?
+
 ## Goals
 * Understand what namespaces are and why they matter
 * Create and explore namespaces using `kubectl`
 * Deploy applications into multiple namespaces and observe isolation
 * Experiment with RBAC basics
 
+## Quick Start
+
+List the namespaces that already exist:
+
+```bash
+kubectl get namespaces
+```
+
+Apply the example manifests to spin up [Ollama](https://ollama.ai) in its own namespace and a [LibreChat](https://github.com/danny-avila/librechat) frontend in another:
+
+```bash
+kubectl apply -f ollama.yaml
+kubectl apply -f librechat.yaml
+```
+
+List the pods in each namespace:
+
+```bash
+kubectl get pods -n ollama
+kubectl get pods -n chat
+```
+
+The Ollama service is exposed on `localhost:11434` thanks to the devcontainer's kind configuration. LibreChat is available on `localhost:3080`. Service discovery works via CoreDNS so LibreChat can reach Ollama at `ollama.ollama.svc.cluster.local`.
+
+If you want to test RBAC isolation, apply `rbac.yaml` after the deployments. The role prevents the `chat` service account from listing resources in the `ollama` namespace:
+
+```bash
+kubectl apply -f rbac.yaml
+```
+
+Try listing pods as the service account and note the `Forbidden` error.
+
+Clean up everything by deleting the namespaces:
+
+```bash
+kubectl delete namespace chat ollama
+```
+
 ## Exercises
-1. Create a namespace and deploy a service in it.
+1. Deploy the Ollama and LibreChat manifests.
 2. Explore namespace‑scoped commands (`kubectl get pods -n <name>`).
-3. Deploy a second instance of the same service in another namespace.
-4. Break something and fix it.
+3. Test that LibreChat can reach the Ollama service.
+4. Create an RBAC role that denies the LibreChat service account access to the `ollama` namespace and verify it cannot list pods there.
 
 _Optional_: Use [Ollama](https://ollama.ai) to generate namespace‑scoped manifests.

--- a/sessions/01-namespace-of-mind/librechat.yaml
+++ b/sessions/01-namespace-of-mind/librechat.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chat
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: librechat
+  namespace: chat
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: librechat
+  template:
+    metadata:
+      labels:
+        app: librechat
+    spec:
+      containers:
+      - name: librechat
+        image: ghcr.io/danny-avila/librechat:latest
+        env:
+        - name: OLLAMA_BASE_URL
+          value: http://ollama.ollama.svc.cluster.local:11434
+        ports:
+        - containerPort: 3080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: librechat
+  namespace: chat
+spec:
+  type: NodePort
+  ports:
+  - port: 3080
+    targetPort: 3080
+    nodePort: 31080
+  selector:
+    app: librechat

--- a/sessions/01-namespace-of-mind/ollama.yaml
+++ b/sessions/01-namespace-of-mind/ollama.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollama
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      containers:
+      - name: ollama
+        image: ollama/ollama:latest
+        ports:
+        - containerPort: 11434
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  type: NodePort
+  ports:
+  - port: 11434
+    targetPort: 11434
+    nodePort: 31434
+  selector:
+    app: ollama

--- a/sessions/01-namespace-of-mind/rbac.yaml
+++ b/sessions/01-namespace-of-mind/rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: librechat
+  namespace: chat
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deny-ollama
+  namespace: ollama
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: librechat-deny
+  namespace: ollama
+subjects:
+- kind: ServiceAccount
+  name: librechat
+  namespace: chat
+roleRef:
+  kind: Role
+  name: deny-ollama
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary
- flesh out details in `01-namespace-of-mind` for creating and using namespaces
- show how to deploy Ollama with a LibreChat frontend in another namespace
- expose ports in a kind cluster using a new `kind-config.yaml`
- document the devcontainer features

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840da7952488321a8b0f9dbea710b29